### PR TITLE
Fix coursier cache, update Codacy coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-sudo: false
+os: linux
 language: scala
 scala:
-  - 2.12.5
+  - 2.12.10
 jdk:
   - oraclejdk8
 install:
@@ -13,14 +13,15 @@ install:
   - npm install jsdom source-map-support
 script:
   - sbt clean +test
-  - sbt coverage coreJVM/test communicationJVM/test server/test serverUndertow/test stream/test appJVM/test
-  - sbt coverageReport
+  - sbt coverage coreJVM/test communicationJVM/test server/test serverUndertow/test stream/test appJVM/test coverageReport
   - sbt coverageAggregate
-  - sbt codacyCoverage
+  - bash <(curl -Ls https://coverage.codacy.com/get.sh) report --skip
 cache:
   directories:
+    - $HOME/.cache/coursier/v1
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot
+    - .coverage-reporter
 before_cache:
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
   - find $HOME/.sbt -name "*.lock" -delete

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.3
+sbt.version=1.3.8


### PR DESCRIPTION
- Codacy deprecated the sbt plugin. It now exposes a script that downloads a graalvm binary.
- Added `skip` option to allow CI to pass on forks.
- Fix travis deprecations.
- Add [Coursier cache directory](https://get-coursier.io/docs/cache.html#default-location) \(sbt 1.3.x\)